### PR TITLE
show alpha ivs in aggressive pathfinding

### DIFF
--- a/main.py
+++ b/main.py
@@ -202,7 +202,7 @@ def generate_mass_outbreak(main_rng,rolls,spawns,poke_filter):
         alpha = slot >= 100
         fixed_seed = fixed_rng.next()
         encryption_constant,pid,ivs,ability,gender,nature,shiny = \
-            generate_from_seed(fixed_seed,rolls,0)
+            generate_from_seed(fixed_seed,rolls,3 if alpha else 0)
         display += f"<b>Init Spawn {init_spawn}</b> <b>Shiny: " \
                    f"<font color=\"{'green' if shiny else 'red'}\">{shiny}</font></b><br>" \
                    f"<b>Alpha: <font color=\"{'green' if alpha else 'red'}\">" \
@@ -225,7 +225,7 @@ def generate_mass_outbreak(main_rng,rolls,spawns,poke_filter):
         alpha = slot >= 100
         fixed_seed = fixed_rng.next()
         encryption_constant,pid,ivs,ability,gender,nature,shiny = \
-            generate_from_seed(fixed_seed,rolls,0)
+            generate_from_seed(fixed_seed,rolls,3 if alpha else 0)
         display += f"<b>Respawn {respawn}</b> Shiny: " \
                    f"<b><font color=\"{'green' if shiny else 'red'}\">{shiny}</font></b><br>" \
                    f"<b>Alpha: <font color=\"{'green' if alpha else 'red'}\">" \

--- a/main.py
+++ b/main.py
@@ -337,9 +337,9 @@ def generate_mass_outbreak_aggressive_path(group_seed,rolls,steps,poke_filter,un
             alpha = slot >= 100
             fixed_seed = fixed_rng.next()
             encryption_constant,pid,ivs,ability,gender,nature,shiny = \
-                generate_from_seed(fixed_seed,rolls,0)
+                generate_from_seed(fixed_seed,rolls,3 if alpha else 0)
             filtered = ((poke_filter['shinyFilterCheck'] and not shiny)
-                      or poke_filter['outbreakAlphaFilter'] and not 100 <= slot < 101)
+                      or poke_filter['outbreakAlphaFilter'] and not alpha)
             if not filtered and not fixed_seed in uniques:
                 uniques.add(fixed_seed)
                 storage.append(


### PR DESCRIPTION
I haven't tested this on a real spawn, but I noticed that aggressive pathfinding wasn't showing the right IVs for alpha spawns after the inital ones

EDIT - I found two more places that weren't taking into account if a mon was alpha and included them